### PR TITLE
Solve the Nativescript +2.2 version issue

### DIFF
--- a/ripple.android.ts
+++ b/ripple.android.ts
@@ -128,14 +128,14 @@ export class Ripple extends ContentView {
 
     public _addChildFromBuilder(name: string, value: any) {
         // Copy inheirtable style property values
-        var originalColor = value.style.color || null;
+        //var originalColor = value.style.color || null;
 
         if (value instanceof View) {
             this.content = value;
         }
 
         // Reset inheritable style property values as we do not want those to be inherited
-        value.style.color = originalColor;
+        //value.style.color = originalColor;
     }
 
 


### PR DESCRIPTION
Solve the +2.2 version issue, that occurs when the child view is a Label and tries to set Color Style when the view has no default color set on XML
